### PR TITLE
add prepop cql file

### DIFF
--- a/CRD-DTR/RemsDrugs/R4/files/RemsDrugsPrepopulation-0.1.0.cql
+++ b/CRD-DTR/RemsDrugs/R4/files/RemsDrugsPrepopulation-0.1.0.cql
@@ -7,60 +7,124 @@ include DTRHelpers version '0.1.0' called DTR
 codesystem "ICD-10-CM": 'http://hl7.org/fhir/sid/icd-10-cm'
 codesystem "LOINC": 'http://loinc.org'
 codesystem "SNOMED-CT": 'http://snomed.info/sct'
+codesystem "RXNORM": 'http://www.nlm.nih.gov/research/umls/rxnorm'
 
-valueset "OrganTransplantHistoryValueSet": 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.81'
-valueset "OrganTransplantProcedureValueSet": 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.90'
-valueset "ImmunosuppressiveMedicationValueSet": 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.192'
-valueset "ImmunosuppressiveSupportiveMedicationValueSet": 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.193'
 
+valueset "HepaticMedicalHistory": 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.198'
+valueset "TuralioValueSet": 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.197'
+
+code "29463-7": '29463-7' from "LOINC"
+code "2183102": '2183102' from "RXNORM"
+code "AST": '1920-8' from "LOINC"
+code "ALT": '1742-6' from "LOINC"
+code "GGT": '2324-2' from "LOINC"
+code "TotalBilirubin": '1975-2' from "LOINC"
+code "DirectBilirubin": '1968-7' from "LOINC"
+code "ALP": '13874-3' from "LOINC"
+code "Albumin": '1751-7' from "LOINC"
+code "PT": '5902-2' from "LOINC"
 
 parameter medication_request MedicationRequest
 parameter medication_dispense MedicationDispense
 
 context Patient
 
-define "QualifyingTransplant": [Condition: "OrganTransplantHistoryValueSet"] 
+// get observations 
+define "WeightList": [Observation: "29463-7"]
+define "LatestWeight": CDS.MostRecent(CDS.WithUnit(CDS.Verified("WeightList"),'mg'))
+define "LatestWeightResult": DTR.GetObservationValue("LatestWeight")
 
-define "QualifyingTransplantProcedures": [Procedure: "OrganTransplantProcedureValueSet"]
-
-define "QualifyingTransplantCodings": DTR.CodesFromConditions("QualifyingTransplant") union DTR.CodesFromProcedures("QualifyingTransplantProcedures")
-
-// get the first transplant date
-define "TransplantDate": 
-  if exists("QualifyingTransplant") then First("QualifyingTransplant").recordedDate.value
-  else First("QualifyingTransplantProcedures").performed.value union First("QualifyingTransplantProcedures").performed.start.value
-
-// Get all medication related information
-define "MedicationCodingFromParameter": Coalesce(medication_request.medication.coding, medication_dispense.medication.coding)
-
-define MedicationCoding: singleton from (
-    "MedicationCodingFromParameter" CODING
-    where CODING in "ImmunosuppressiveMedicationValueSet" 
-    or CODING in "ImmunosuppressiveSupportiveMedicationValueSet")
-
-define "MedicationName": MedicationCoding.display.value
-
-define "MedicationCode" : MedicationCoding.code.value
-
-define "MedicationDosage": Coalesce(medication_request.dosageInstruction[0], medication_dispense.dosageInstruction[0])
-
-define "MedicationDoseAndRate": MedicationDosage.doseAndRate[0]
-
-define "MedicationDoseWithUnit": ToString(MedicationDoseAndRate.dose.value.value) + ' ' + MedicationDoseAndRate.dose.unit.value
-
-define "MedicationRoute": MedicationDosage.route.coding[0].display.value
-
-define "MedicationFrequency" : ToString(MedicationDosage.timing.repeat.frequency.value) + ' per ' + ToString(MedicationDosage.timing.repeat.period.value) + '' + MedicationDosage.timing.repeat.periodUnit.value
-
-define CurrentDiagnoses:
-  DTR.CodesFromConditions(CDS.Confirmed(CDS.ActiveOrRecurring([Condition]))) except QualifyingTransplant
-
-define "MedicationQuantity": Coalesce(medication_dispense.quantity.value, medication_request.dispenseRequest.quantity.value.value)
-
-define "MedicationRefill": 
-  if medication_request.dispenseRequest is not null
-    then medication_request.dispenseRequest.numberOfRepeatsAllowed.value
+define "Turalio": [MedicationStatement: "TuralioValueSet"]
+define "TakingTuralio": exists("Turalio")
+define "TuralioDate": 
+  if "TakingTuralio" 
+    then First("Turalio").effective.value
   else
-    null  
+    null
 
-define "IsMedicationRequest": medication_request.id is not null
+define "LatestAST": CDS.MostRecent(CDS.WithUnit(CDS.Verified([Observation: "AST"]), 'U/L'))
+define "ASTResult": (convert DTR.GetObservationValue("LatestAST") to String) + ' U/L'
+define "ASTDate": 
+  if exists("LatestAST")
+    then "LatestAST".issued.value
+  else
+    null
+
+define "LatestALT": CDS.MostRecent(CDS.WithUnit(CDS.Verified([Observation: "ALT"]), 'U/L'))
+define "ALTResult": (convert DTR.GetObservationValue("LatestALT") to String) + ' U/L'
+define "ALTDate": 
+  if exists("LatestALT")
+    then "LatestALT".issued.value
+  else
+    null
+
+define "LatestGGT": CDS.MostRecent(CDS.WithUnit(CDS.Verified([Observation: "GGT"]), 'U/L'))
+define "GGTResult": (convert DTR.GetObservationValue("LatestGGT") to String) + ' U/L'
+define "GGTDate": 
+  if exists("LatestGGT")
+    then "LatestGGT".issued.value
+  else
+    null
+
+define "LatestTotalBilirubin": CDS.MostRecent(CDS.WithUnit(CDS.Verified([Observation: "TotalBilirubin"]), 'mg/dL'))
+define "TotalBilirubinResult": (convert DTR.GetObservationValue("LatestTotalBilirubin") to String) + ' mg/dL'
+define "TotalBilirubinDate": 
+  if exists("LatestTotalBilirubin")
+    then "LatestTotalBilirubin".issued.value
+  else
+    null
+
+define "LatestDirectBilirubin": CDS.MostRecent(CDS.WithUnit(CDS.Verified([Observation: "DirectBilirubin"]), 'mg/dL'))
+define "DirectBilirubinResult": (convert DTR.GetObservationValue("LatestDirectBilirubin") to String) + ' mg/dL'
+define "DirectBilirubinDate": 
+  if exists("LatestDirectBilirubin")
+    then "LatestDirectBilirubin".issued.value
+  else
+    null
+
+define "LatestALP": CDS.MostRecent(CDS.WithUnit(CDS.Verified([Observation: "ALP"]), 'U/L'))
+define "ALPResult": (convert DTR.GetObservationValue("LatestALP") to String) + ' U/L'
+define "ALPDate": 
+  if exists("LatestALP")
+    then "LatestALP".issued.value
+  else
+    null
+
+define "LatestAlbumin": CDS.MostRecent(CDS.WithUnit(CDS.Verified([Observation: "Albumin"]), 'g/dL'))
+define "AlbuminResult": (convert DTR.GetObservationValue("LatestAlbumin") to String) + ' g/dL'
+define "AlbuminDate": 
+  if exists("LatestAlbumin")
+    then "LatestAlbumin".issued.value
+  else
+    null
+
+define "LatestPT": CDS.MostRecent(CDS.WithUnit(CDS.Verified([Observation: "PT"]), 's'))
+define "PTResult": (convert DTR.GetObservationValue("LatestPT") to String) + ' s'
+define "PTDate": 
+  if exists("LatestPT")
+    then "LatestPT".issued.value
+  else
+    null
+
+define "MedList": [MedicationStatement] M
+  where M.status.value = 'active'
+
+define "TakingMeds": not exists("MedList")
+define function GetMedicationsTupleList(MedStatementList List<MedicationStatement>):
+  distinct(
+    flatten(
+      MedStatementList MedStatement
+        let MedicationList:
+          (MedStatement.medication.coding) CODING
+          return (FHIRHelpers.ToCode(CODING).display + ' - ' + FHIRHelpers.ToCode(CODING).code)
+
+        return MedicationList  
+    )
+  )   
+define "Meds": GetMedicationsTupleList(MedList)
+define "MedsString": 
+  Meds M
+    aggregate Result starting '': Result + ', ' + M
+
+define "MedicalHistoryList": [Condition: "HepaticMedicalHistory"]
+define "MedicalHistory": DTR.CodesFromConditions(CDS.Confirmed("MedicalHistoryList"))

--- a/CRD-DTR/RemsDrugs/R4/resources/Library-R4-RemsDrugs-prepopulation.json
+++ b/CRD-DTR/RemsDrugs/R4/resources/Library-R4-RemsDrugs-prepopulation.json
@@ -38,6 +38,15 @@
             ]
         },
         {
+            "type": "Condition",
+            "codeFilter": [
+                {
+                    "path": "code",
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.198"
+                }
+            ]
+        },
+        {
             "type": "Procedure",
             "codeFilter": [
                 {
@@ -61,6 +70,18 @@
                 {
                     "path": "code",
                     "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.193"
+                }
+            ]
+        },
+        {
+            "type": "Observation"
+        },
+        {
+            "type": "MedicationStatement",
+            "codeFilter": [
+                {
+                    "path": "code",
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.197"
                 }
             ]
         }

--- a/CRD-DTR/RemsDrugs/R4/resources/Questionnaire-R4-Turalio.json
+++ b/CRD-DTR/RemsDrugs/R4/resources/Questionnaire-R4-Turalio.json
@@ -138,6 +138,13 @@
               "valueCoding": {
                 "display": "lbs"
               }
+            },
+            {
+              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"RemsDrugsPrepopulation\".LatestWeightResult"
+              }
             }
           ],
           "linkId": "1.9",
@@ -230,11 +237,29 @@
           "linkId": "1.12",
           "text": "Is the patient currently taking pexidartinib (i.e., started prior to REMS enrollment)?",
           "type": "boolean",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"RemsDrugsPrepopulation\".TakingTuralio"
+              }
+            }
+          ],
           "required": false,
           "item": [
             {
               "type": "date",
               "linkId": "1.12.1",
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"RemsDrugsPrepopulation\".TuralioDate"
+                  }
+                }
+              ],
               "text": "If yes: When did patient start pexidartinib? Date (MM/DD/YYYY):",
               "enableWhen": [
                 {
@@ -455,13 +480,31 @@
               "linkId": "3.1.2",
               "text": "Baseline Value (units, reference range)",
               "type": "string",
-              "required": false
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"RemsDrugsPrepopulation\".ASTResult"
+                  }
+                }
+              ]
             },
             {
               "linkId": "3.1.3",
               "text": "Date",
               "type": "date",
-              "required": false
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"RemsDrugsPrepopulation\".ASTDate"
+                  }
+                }
+              ]
             }
           ]
         },
@@ -495,13 +538,31 @@
               "linkId": "3.1.2",
               "text": "Baseline Value (units, reference range)",
               "type": "string",
-              "required": false
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"RemsDrugsPrepopulation\".ALTResult"
+                  }
+                }
+              ]
             },
             {
               "linkId": "3.1.3",
               "text": "Date",
               "type": "date",
-              "required": false
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"RemsDrugsPrepopulation\".ALTDate"
+                  }
+                }
+              ]
             }
           ]
         },
@@ -535,13 +596,31 @@
               "linkId": "3.1.2",
               "text": "Baseline Value (units, reference range)",
               "type": "string",
-              "required": false
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"RemsDrugsPrepopulation\".GGTResult"
+                  }
+                }
+              ]
             },
             {
               "linkId": "3.1.3",
               "text": "Date",
               "type": "date",
-              "required": false
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"RemsDrugsPrepopulation\".GGTDate"
+                  }
+                }
+              ]
             }
           ]
         },
@@ -575,13 +654,31 @@
               "linkId": "3.1.2",
               "text": "Baseline Value (units, reference range)",
               "type": "string",
-              "required": false
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"RemsDrugsPrepopulation\".TotalBilirubinResult"
+                  }
+                }
+              ]
             },
             {
               "linkId": "3.1.3",
               "text": "Date",
               "type": "date",
-              "required": false
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"RemsDrugsPrepopulation\".TotalBilirubinDate"
+                  }
+                }
+              ]
             }
           ]
         },
@@ -615,13 +712,31 @@
               "linkId": "3.1.2",
               "text": "Baseline Value (units, reference range)",
               "type": "string",
-              "required": false
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"RemsDrugsPrepopulation\".DirectBilirubinResult"
+                  }
+                }
+              ]
             },
             {
               "linkId": "3.1.3",
               "text": "Date",
               "type": "date",
-              "required": false
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"RemsDrugsPrepopulation\".DirectBilirubinDate"
+                  }
+                }
+              ]
             }
           ]
         },
@@ -655,13 +770,31 @@
               "linkId": "3.1.2",
               "text": "Baseline Value (units, reference range)",
               "type": "string",
-              "required": false
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"RemsDrugsPrepopulation\".ALPResult"
+                  }
+                }
+              ]
             },
             {
               "linkId": "3.1.3",
               "text": "Date",
               "type": "date",
-              "required": false
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"RemsDrugsPrepopulation\".ALPDate"
+                  }
+                }
+              ]
             }
           ]
         },
@@ -695,13 +828,31 @@
               "linkId": "3.1.2",
               "text": "Baseline Value (units, reference range)",
               "type": "string",
-              "required": false
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"RemsDrugsPrepopulation\".AlbuminResult"
+                  }
+                }
+              ]
             },
             {
               "linkId": "3.1.3",
               "text": "Date",
               "type": "date",
-              "required": false
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"RemsDrugsPrepopulation\".AlbuminDate"
+                  }
+                }
+              ]
             }
           ]
         },
@@ -735,13 +886,31 @@
               "linkId": "3.1.2",
               "text": "Baseline Value (units, reference range)",
               "type": "string",
-              "required": false
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"RemsDrugsPrepopulation\".PTResult"
+                  }
+                }
+              ]
             },
             {
               "linkId": "3.1.3",
               "text": "Date",
               "type": "date",
-              "required": false
+              "required": false,
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                  "valueExpression": {
+                    "language": "text/cql",
+                    "expression": "\"RemsDrugsPrepopulation\".PTDate"
+                  }
+                }
+              ]
             }
           ]
         }
@@ -759,7 +928,16 @@
           "required": false,
           "initial": {
             "value": false
-          }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"RemsDrugsPrepopulation\".TakingMeds"
+              }
+            }
+          ]
         },
         {
           "linkId": "4.2",
@@ -771,6 +949,15 @@
               "question": "4.1",
               "operator": "=",
               "answerBoolean": false
+            }
+          ],
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"RemsDrugsPrepopulation\".Meds"
+              }
             }
           ]
         }
@@ -794,6 +981,15 @@
           "linkId": "5.2",
           "text": "Check all that apply",
           "type": "choice",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+              "valueExpression": {
+                "language": "text/cql",
+                "expression": "\"RemsDrugsPrepopulation\".MedicalHistory"
+              }
+            }
+          ],
           "required": true,
           "repeats": true,
           "enableWhen": [
@@ -806,103 +1002,120 @@
           "answerOption": [
             {
               "valueCoding": {
-                "code": "Hepatitis Viral Status",
+                "code": "3738000",
+                "system": "http://snomed.info/sct",
                 "display": "Hepatitis Viral Status"
               }
             },
             {
               "valueCoding": {
-                "code": "Hepatic Cysts",
+                "code": "85057007",
+                "system": "http://snomed.info/sct",
                 "display": "Hepatic Cyst"
               }
             },
             {
               "valueCoding": {
-                "code": "Ischemic Hepatitis",
+                "code": "235877000",
+                "system": "http://snomed.info/sct",
                 "display": "Ischemic Hepatitis"
               }
             },
             {
               "valueCoding": {
-                "code": "Alcohol Abuse",
+                "code": "15167005",
+                "system": "http://snomed.info/sct",
                 "display": "Alcohol Abuse"
               }
             },
             {
               "valueCoding": {
-                "code": "Family History of Liver Disease",
+                "code": "266902008",
+                "system": "http://snomed.info/sct",
                 "display": "Family History of Liver Disease"
               }
             },
             {
               "valueCoding": {
-                "code": "Autoimmune Hepatitis",
+                "code": "408335007",
+                "system": "http://snomed.info/sct",
                 "display": "Autoimmune Hepatitis"
               }
             },
             {
               "valueCoding": {
-                "code": "Wilson’s Disease",
+                "code": "88518009",
+                "system": "http://snomed.info/sct",
                 "display": "Wilson’s Disease"
               }
             },
             {
               "valueCoding": {
-                "code": "Drug Abuse",
+                "code": "26416006",
+                "system": "http://snomed.info/sct",
                 "display": "Drug Abuse"
               }
             },
             {
               "valueCoding": {
-                "code": "Gilbert’s syndrome",
+                "code": "27503000",
+                "system": "http://snomed.info/sct",
                 "display": "Gilbert’s syndrome"
               }
             },
             {
               "valueCoding": {
-                "code": "Hypolipoproteinemia",
+                "code": "363140000",
+                "system": "http://snomed.info/sct",
                 "display": "Hypolipoproteinemia"
               }
             },
             {
               "valueCoding": {
-                "code": "Familial Hyperbilirubinemia",
+                "code": "14783006",
+                "system": "http://snomed.info/sct",
                 "display": "Familial Hyperbilirubinemia"
               }
             },
             {
               "valueCoding": {
-                "code": "Anorexia",
+                "code": "56882008",
+                "system": "http://snomed.info/sct",
                 "display": "Anorexia"
               }
             },
             {
               "valueCoding": {
-                "code": "Biliary Tract Disorder",
+                "code": "105997008",
+                "system": "http://snomed.info/sct",
                 "display": "Biliary Tract Disorder"
               }
             },
             {
               "valueCoding": {
-                "code": "Hypertriglyceridemia",
+                "code": "302870006",
+                "system": "http://snomed.info/sct",
                 "display": "Hypertriglyceridemia"
               }
             },
             {
               "valueCoding": {
-                "code": "Cirrhosis",
+                "code": "19943007",
+                "system": "http://snomed.info/sct",
                 "display": "Cirrhosis"
               }
             },
             {
               "valueCoding": {
-                "code": "Gallbladder Disease/ Gallstones/ Bile Duct Occlusion",
+                "code": "39621005",
+                "system": "http://snomed.info/sct",
                 "display": "Gallbladder Disease/ Gallstones/ Bile Duct Occlusion"
               }
             },
             {
               "valueCoding": {
-                "code": "Diabetes",
+                "code": "73211009",
+                "system": "http://snomed.info/sct",
                 "display": "Diabetes"
               }
             }


### PR DESCRIPTION
Adds the files needed for doing the prepopulation, including the CQL file and a couple changes to the library and questionnaire files.  Note that there are two new valuesets that are required for use, so you will either have to provide a VSAC API key in your environment or manually reload the data at http://localhost:8090/data using your VSAC API key.