### PR TITLE
add cql for prescriber form

### DIFF
--- a/CRD-DTR/DrugHasREMS/R4/files/DrugHasREMSPrescriberEnrollmentPrepopulation-0.1.0.cql
+++ b/CRD-DTR/DrugHasREMS/R4/files/DrugHasREMSPrescriberEnrollmentPrepopulation-0.1.0.cql
@@ -1,0 +1,44 @@
+library DrugHasREMSPrescriberEnrollmentPrepopulation  version '0.1.0'
+using FHIR version '4.0.0'
+include FHIRHelpers version '4.0.0' called FHIRHelpers
+
+codesystem "ICD-10-CM": 'http://hl7.org/fhir/sid/icd-10-cm'
+codesystem "LOINC": 'http://loinc.org'
+codesystem "SNOMED-CT": 'http://snomed.info/sct'
+codesystem "RXNORM": 'http://www.nlm.nih.gov/research/umls/rxnorm'
+
+code "Oncologist":'394592004' from "SNOMED-CT"
+
+parameter device_request DeviceRequest
+parameter service_request ServiceRequest
+parameter medication_request MedicationRequest
+
+context Patient
+
+define Today: Today()
+
+define "SigningProviderReference": Coalesce(device_request.performer.reference.value, service_request.performer.reference.value, medication_request.requester.reference.value)
+// Get Practitioner
+define OrderingProvider: singleton from (
+  [Practitioner] practitioner
+    where ('Practitioner/' + practitioner.id) =  SigningProviderReference)
+
+define Qualifications: singleton from (
+    "OrderingProvider".qualification[0].code.coding[0].code.value)
+
+define Credentials: {Qualifications}
+
+define PractitionerRole: singleton from (
+  [PractitionerRole] prole
+    where (prole.practitioner.reference.value) = SigningProviderReference)
+
+define Specialty:  FHIRHelpers.ToConcept("PractitionerRole".specialty[0] as FHIR.CodeableConcept).codes
+
+define PreferredCommunication: {(singleton from (
+  "OrderingProvider".telecom telecom where telecom.rank.value = 1)).system.value}
+
+define OrgName: ([Organization] org).name.value
+
+define MD: (singleton from (
+  "OrderingProvider".identifier identifier
+    where identifier.type.coding[0].code = 'MD')).value.value

--- a/CRD-DTR/DrugHasREMS/R4/resources/Library-R4-DrugHasREMSPrescriberEnrollment-prepopulation.json
+++ b/CRD-DTR/DrugHasREMS/R4/resources/Library-R4-DrugHasREMSPrescriberEnrollment-prepopulation.json
@@ -1,0 +1,109 @@
+{
+  "resourceType": "Library",
+  "id": "DrugHasREMSPrescriberEnrollment-prepopulation",
+  "url": "http://hl7.org/fhir/us/davinci-dtr/Library/DrugHasREMSPrescriberEnrollment-prepopulation",
+  "name": "DrugHasREMSPrescriberEnrollment-prepopulation",
+  "version": "0.1.0",
+  "title": "DrugHasREMSPrescriberEnrollment Prepopulation",
+  "status": "draft",
+  "type": {
+    "coding": [
+      {
+        "code": "logic-library"
+      }
+    ]
+  },
+  "relatedArtifact": [
+    {
+      "type": "depends-on",
+      "resource": "Library/FHIRHelpers-4.0.0"
+    },
+    {
+      "type": "depends-on",
+      "resource": "Library/CDS_Connect_Commons_for_FHIRv400"
+    },
+    {
+      "type": "depends-on",
+      "resource": "Library/DTRHelpers"
+    }
+  ],
+  "dataRequirement": [
+    {
+      "type": "Condition",
+      "codeFilter": [
+        {
+          "path": "code",
+          "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.81"
+        }
+      ]
+    },
+    {
+      "type": "Condition",
+      "codeFilter": [
+        {
+          "path": "code",
+          "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.198"
+        }
+      ]
+    },
+    {
+      "type": "Procedure",
+      "codeFilter": [
+        {
+          "path": "code",
+          "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.90"
+        }
+      ]
+    },
+    {
+      "type": "MedicationRequest",
+      "codeFilter": [
+        {
+          "path": "code",
+          "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.192"
+        }
+      ]
+    },
+    {
+      "type": "MedicationRequest",
+      "codeFilter": [
+        {
+          "path": "code",
+          "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.193"
+        }
+      ]
+    },
+    {
+      "type": "Observation"
+    },
+    {
+      "type": "MedicationStatement",
+      "codeFilter": [
+        {
+          "path": "code",
+          "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.197"
+        }
+      ]
+    },
+    {
+      "type": "Practitioner"
+    },
+    {
+      "type": "PractitionerRole",
+      "subjectCodeableConcept": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/ValueSet/subject-type",
+            "code": "Practitioner"
+          }
+        ]
+      }
+    }
+  ],
+  "content": [
+    {
+      "contentType": "application/elm+json",
+      "url": "files/DrugHasREMS/r4/DrugHasREMSPrescriberEnrollmentPrepopulation-0.1.0.cql"
+    }
+  ]
+}

--- a/CRD-DTR/DrugHasREMS/R4/resources/Questionnaire-R4-Prescriber-Knowledge-Assessment.json
+++ b/CRD-DTR/DrugHasREMS/R4/resources/Questionnaire-R4-Prescriber-Knowledge-Assessment.json
@@ -31,7 +31,7 @@
                         "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
                         "valueExpression": {
                           "language": "text/cql",
-                          "expression": "\"BasicClinicalInfoPrepopulation\".EncounterProviderFirstName"
+                          "expression": "\"BasicPractitionerInfoPrepopulation\".FirstName"
                         }
                       },
                       {
@@ -50,7 +50,7 @@
                         "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
                         "valueExpression": {
                           "language": "text/cql",
-                          "expression": "\"BasicClinicalInfoPrepopulation\".EncounterProviderLastName"
+                          "expression": "\"BasicPractitionerInfoPrepopulation\".LastName"
                         }
                       },
                       {
@@ -69,7 +69,7 @@
                         "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
                         "valueExpression": {
                           "language": "text/cql",
-                          "expression": "\"BasicClinicalInfoPrepopulation\".EncounterProviderMiddleInitial"
+                          "expression": "\"BasicPractitionerInfoPrepopulation\".MiddleInitial"
                         }
                       }
                     ]
@@ -84,7 +84,7 @@
                         "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
                         "valueExpression": {
                           "language": "text/cql",
-                          "expression": "\"BasicClinicalInfoPrepopulation\".EncounterProviderNPI"
+                          "expression": "\"BasicPractitionerInfoPrepopulation\".NPI"
                         }
                       }
                     ]
@@ -93,19 +93,46 @@
                     "linkId": "1.5",
                     "text": "Phone Number",
                     "type": "string",
-                    "required": true
+                    "required": true,
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                        "valueExpression": {
+                          "language": "text/cql",
+                          "expression": "\"BasicPractitionerInfoPrepopulation\".Phone"
+                        }
+                      }
+                    ]
                 },
                 {
                     "linkId": "1.6",
                     "text": "Fax Number",
                     "type": "string",
-                    "required": true
+                    "required": true,
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                        "valueExpression": {
+                          "language": "text/cql",
+                          "expression": "\"BasicPractitionerInfoPrepopulation\".Fax"
+                        }
+                      }
+                    ]
                 },
                 {
                     "linkId": "1.7",
                     "text": "Email",
                     "type": "string",
-                    "required": true
+                    "required": true,
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                        "valueExpression": {
+                          "language": "text/cql",
+                          "expression": "\"BasicPractitionerInfoPrepopulation\".Email"
+                        }
+                      }
+                    ]
                 }
             ]
         },
@@ -117,7 +144,7 @@
                 {
                     "linkId": "2.1",
                     "text": "1. TURALIO is indicated for the treatment of adult patients with symptomatic tenosynovial giant cell tumor (TGCT) associated with severe morbidity or functional limitations and not amenable to improvement with surgery.",
-                    "type": "open-choice",
+                    "type": "choice",
                     "answerOption": [
                         {
                           "valueCoding": {
@@ -136,7 +163,7 @@
                 {
                     "linkId": "2.2",
                     "text": "2. TURALIO is contraindicated in patients with hepatic impairment.",
-                    "type": "open-choice",
+                    "type": "choice",
                     "answerOption": [
                         {
                           "valueCoding": {
@@ -155,7 +182,7 @@
                 {
                     "linkId": "2.3",
                     "text": "3. To prescribe TURALIO, I must enroll each patient in the TURALIO REMS by completing a Patient Enrollment Form with the patient and submitting it to the TURALIO REMS.",
-                    "type": "open-choice",
+                    "type": "choice",
                     "answerOption": [
                         {
                           "valueCoding": {
@@ -174,7 +201,7 @@
                 {
                     "linkId": "2.4",
                     "text": "4. Before treating each patient with TURALIO, I must",
-                    "type": "open-choice",
+                    "type": "choice",
                     "answerOption": [
                         {
                           "valueCoding": {
@@ -205,7 +232,7 @@
                 {
                     "linkId": "2.5",
                     "text": "5. One of the primary counseling messages I must tell my patients before prescribing TURALIO is",
-                    "type": "open-choice",
+                    "type": "choice",
                     "answerOption": [
                         {
                           "valueCoding": {
@@ -236,7 +263,7 @@
                 {
                     "linkId": "2.6",
                     "text": "6. I am required to educate my patients on the signs and symptoms of liver injury and the need to notify me should they experience them.",
-                    "type": "open-choice",
+                    "type": "choice",
                     "answerOption": [
                         {
                           "valueCoding": {
@@ -255,7 +282,7 @@
                 {
                     "linkId": "2.7",
                     "text": "7. If any dose modifications are required, they must be done in increments of 200 mg.",
-                    "type": "open-choice",
+                    "type": "choice",
                     "answerOption": [
                         {
                           "valueCoding": {
@@ -274,7 +301,7 @@
                 {
                     "linkId": "2.8",
                     "text": "8. After treatment initiation, I need to monitor liver tests weekly for the first 8 weeks of treatment, every 2 weeks for the next month, and every 3 months thereafter.",
-                    "type": "open-choice",
+                    "type": "choice",
                     "answerOption": [
                         {
                           "valueCoding": {
@@ -293,7 +320,7 @@
                 {
                     "linkId": "2.9",
                     "text": "9. I must complete a Patient Status Form for each patient taking TURALIO and submit it to the TURALIO REMS:",
-                    "type": "open-choice",
+                    "type": "choice",
                     "answerOption": [
                         {
                           "valueCoding": {

--- a/CRD-DTR/DrugHasREMS/R4/resources/Questionnaire-R4-PrescriberEnrollment.json
+++ b/CRD-DTR/DrugHasREMS/R4/resources/Questionnaire-R4-PrescriberEnrollment.json
@@ -9,6 +9,12 @@
     ],
     "date": "2022-05-28",
     "publisher": "FDA-REMS",
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/cqf-library",
+        "valueCanonical": "http://hl7.org/fhir/us/davinci-dtr/Library/DrugHasREMSPrescriberEnrollment-prepopulation"
+      }
+    ],
     "item": [
         {
             "linkId": "1",
@@ -19,25 +25,61 @@
                     "linkId": "1.1",
                     "text": "First Name",
                     "type": "string",
-                    "required": true
+                    "required": true,
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                      "valueExpression": {
+                        "language": "text/cql",
+                        "expression": "\"BasicPractitionerInfoPrepopulation\".FirstName"
+                      }
+                    }
+                  ]
                 },
                 {
                     "linkId": "1.2",
                     "text": "Last Name",
                     "type": "string",
-                    "required": true
+                    "required": true,
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                      "valueExpression": {
+                        "language": "text/cql",
+                        "expression": "\"BasicPractitionerInfoPrepopulation\".LastName"
+                      }
+                    }
+                  ]
                 },
                 {
                     "linkId": "1.3",
                     "text": "Middle Initial",
                     "type": "string",
-                    "required": false
+                    "required": false,
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                      "valueExpression": {
+                        "language": "text/cql",
+                        "expression": "\"BasicPractitionerInfoPrepopulation\".MiddleInitial"
+                      }
+                    }
+                  ]
                 },
                 {
                     "linkId": "1.4",
                     "text": "Credentials",
                     "type": "open-choice",
                     "required": true,
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                        "valueExpression": {
+                          "language": "text/cql",
+                          "expression": "\"DrugHasREMSPrescriberEnrollmentPrepopulation\".Credentials"
+                        }
+                      }
+                    ],
                     "answerOption": [
                       {
                         "valueCoding": {
@@ -76,10 +118,19 @@
                     "text": "Specialty",
                     "type": "open-choice",
                     "required": true,
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                        "valueExpression": {
+                          "language": "text/cql",
+                          "expression": "\"DrugHasREMSPrescriberEnrollmentPrepopulation\".Specialty"
+                        }
+                      }
+                    ],
                     "answerOption": [
                       {
                         "valueCoding": {
-                          "code": "Oncolgy",
+                          "code": "Oncology",
                           "display": "Oncology"
                         }
                       },
@@ -101,67 +152,166 @@
                     "linkId": "1.6",
                     "text": "National Provider Identifier (NPI) #",
                     "type": "string",
-                    "required": true
+                    "required": true,
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                        "valueExpression": {
+                          "language": "text/cql",
+                          "expression": "\"BasicPractitionerInfoPrepopulation\".NPI"
+                        }
+                      }
+                    ]
                 },
                 {
                   "linkId": "1.7",
                   "text": "State License #",
                   "type": "string",
-                  "required": false
+                  "required": false,
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                      "valueExpression": {
+                        "language": "text/cql",
+                        "expression": "\"DrugHasREMSPrescriberEnrollmentPrepopulation\".MD"
+                      }
+                    }
+                  ]
                 },
                 {
                     "linkId": "1.8",
                     "text": "Practice/Facility Name",
                     "type": "string",
-                    "required": false
+                    "required": false,
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                        "valueExpression": {
+                          "language": "text/cql",
+                          "expression": "\"DrugHasREMSPrescriberEnrollmentPrepopulation\".OrgName"
+                        }
+                      }
+                    ]
                 },
                 {
                     "linkId": "1.9",
                     "text": "Street Address",
                     "type": "string",
-                    "required": true
+                    "required": true,
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                      "valueExpression": {
+                        "language": "text/cql",
+                        "expression": "\"BasicPractitionerInfoPrepopulation\".Line"
+                      }
+                    }
+                  ]
                 },
                 {
                     "linkId": "1.10",
                     "text": "City",
                     "type": "string",
-                    "required": true
+                    "required": true,
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                      "valueExpression": {
+                        "language": "text/cql",
+                        "expression": "\"BasicPractitionerInfoPrepopulation\".City"
+                      }
+                    }
+                  ]
                 },
                 {
                     "linkId": "1.11",
                     "text": "State",
                     "type": "string",
-                    "required": true
+                    "required": true,
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                      "valueExpression": {
+                        "language": "text/cql",
+                        "expression": "\"BasicPractitionerInfoPrepopulation\".State"
+                      }
+                    }
+                  ]
                 },
                 {
                     "linkId": "1.12",
                     "text": "ZIP Code",
                     "type": "string",
-                    "required": true
+                    "required": true,
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                      "valueExpression": {
+                        "language": "text/cql",
+                        "expression": "\"BasicPractitionerInfoPrepopulation\".Zip"
+                      }
+                    }
+                  ]
                 },
                 {
                     "linkId": "1.13",
                     "text": "Office Phone Number",
                     "type": "string",
-                    "required": true
+                    "required": true,
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                      "valueExpression": {
+                        "language": "text/cql",
+                        "expression": "\"BasicPractitionerInfoPrepopulation\".Phone"
+                      }
+                    }
+                  ]
                 },
                 {
                     "linkId": "1.14",
                     "text": "Office Fax Number",
                     "type": "string",
-                    "required": true
+                    "required": true,
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                      "valueExpression": {
+                        "language": "text/cql",
+                        "expression": "\"BasicPractitionerInfoPrepopulation\".Fax"
+                      }
+                    }
+                  ]
                 },
                 {
                     "linkId": "1.15",
                     "text": "E-Mail",
                     "type": "string",
-                    "required": true
+                    "required": true,
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                      "valueExpression": {
+                        "language": "text/cql",
+                        "expression": "\"BasicPractitionerInfoPrepopulation\".Email"
+                      }
+                    }
+                  ]
                 },
                 {
                     "linkId": "1.16",
-                    "text": "Perfered Method of Communication",
+                    "text": "Preferred Method of Communication",
                     "type": "open-choice",
                     "required": false,
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                      "valueExpression": {
+                        "language": "text/cql",
+                        "expression": "\"DrugHasREMSPrescriberEnrollmentPrepopulation\".PreferredCommunication"
+                      }
+                    }
+                  ],
                     "answerOption": [
                       {
                         "valueCoding": {
@@ -185,7 +335,7 @@
                 },
                 {
                     "linkId": "1.17",
-                    "text": "Perferred Time of Contact",
+                    "text": "Preferred Time of Contact",
                     "type": "open-choice",
                     "required": false,
                     "answerOption": [

--- a/CRD-DTR/Shared/R4/files/BasicPractitionerInfoPrepopulation-0.1.0.cql
+++ b/CRD-DTR/Shared/R4/files/BasicPractitionerInfoPrepopulation-0.1.0.cql
@@ -52,3 +52,6 @@ define Phone: (singleton from (
 
 define Email: (singleton from (
   "OrderingProvider".telecom telecom where telecom.system.value = 'email')).value.value
+
+define Fax: (singleton from (
+  "OrderingProvider".telecom telecom where telecom.system.value = 'fax')).value.value


### PR DESCRIPTION
Creates the library/CQL files needed for prepopulation and modifies the Quesetionnaire resource to use the values from the CQL.  Also includes some minor additions to the PractitionerInfo CQL file, for elements that might be common to other prepopulation files.

To test this, use it with the other REMS-179 pull requests and go through a normal turalio ordering workflow with the prescriber enrollment form.  The majority of the fields will be filled out.  As it stands, I'm not sure how to auto-populate the remaining fields as there isn't a good place in the practitioner/practitionerRole resource, or any other FHIR resource really, to put that information.  This is specifically the "best time to contact practitioner" field and the two optional office contacts.  