### PR TITLE
add initial condition of "false" to pregnancy question

### DIFF
--- a/CRD-DTR/IPledge/R4/resources/Questionnaire-R4-IPledge.json
+++ b/CRD-DTR/IPledge/R4/resources/Questionnaire-R4-IPledge.json
@@ -43,6 +43,11 @@
                             "linkId": "1.2.1",
                             "text": "Patient who can get pregnant",
                             "type": "boolean",
+                            "initial": [
+                                {
+                                    "valueBoolean": false
+                                }
+                            ],
                             "required": true
                         }
                     ]


### PR DESCRIPTION
Adds an initial value to the boolean question so that questions associated with "false" will show up when the page loads, rather than requiring the user to double click the checkbox. 

Other solutions were looked into to see if the checkbox could be changed into a radio button so that the form could continue to use its 3 value logic (T, F, Null) but it doesn't seem like LForms supports it.  Another option would be to write some javascript that searches the DOM after it's built to replace LForm HTML with custom HTML, and then hook that back in to the internal QuestionnaireResponse keeping track of the answers, much like the attestation button or filter button are added to the form already, but that would require quite a bit of work for little benefit.  

A more robust option would be to break this form out into an adaptive form where the provider is only shown this question first, before clicking the "next question" button, at which point logic on CRD would return the appropriate form depending on the answer to this boolean.  This would replace the enableWhen logic and would probably be the most "correct" option.